### PR TITLE
Solves Bug #74 : added word-wrap property to solve the issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,6 +74,7 @@ body.dark-mode .list-group-item {
   text-align: left;
   margin-right: 20px;
   border-radius: 5rem !important;
+  word-wrap: break-word;
 }
 
 .list-group-item button {


### PR DESCRIPTION
I have added 'word-wrap: break-word' in '.list-group-item' class to tackle the issue of overflow of text from the todo item.

Kindly review the change and merge if it covers the required test cases.