### PR TITLE
Fixing the Task name UI in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -166,6 +166,7 @@ body.dark-mode::before {
   font-size: 1.3rem;
   margin-top: 0.4rem;
   text-align: left;
+  color: #000;
   margin-right: 20px;
   border-radius: 5rem !important;
   word-break: break-all;


### PR DESCRIPTION
Fixes #102

This Pull request fixes the issue of the task name changing to white color when the app is in dark mode

![image](https://github.com/Kritika30032002/To-Do-List-Application/assets/96657269/3495f0b5-ddba-4d98-b112-85959eca16d1)

This issue occurred because of changing the text color to white when dark-mode is toggled
`body.dark-mode {
  color: #fff; /* Text color for dark mode */
}`

I fixed this issue by making the text color of list-goup-item black so that it can't be changed by the body color change

`.list-group-item { color: #000; }`