### PR TITLE
styled the slider for dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -705,26 +705,35 @@ h4 {
   }
 }
 
-body::-webkit-scrollbar {
-  width: 0.5em;
-  background-color: rgba(255, 255, 255, 0.989);
+body:not(.dark-mode)::-webkit-scrollbar {
+  width: 12px;
+  background-color: #dfe6e9;
 }
 
-body::-webkit-scrollbar-track {
-  box-shadow: inset 0 0 6px rgba(81, 81, 81, 0.95);
+body:not(.dark-mode)::-webkit-scrollbar-track {
+  border: 5px solid white;
+  background-color: #000000;
 }
 
-body::-webkit-scrollbar-thumb {
-  background: rgb(2, 0, 36);
-  background: linear-gradient(
-    90deg,
-    rgba(2, 0, 36, 1) 0%,
-    rgba(9, 9, 121, 1) 35%,
-    rgba(0, 212, 255, 1) 100%
-  );
-  border-radius: 5px;
+body:not(.dark-mode)::-webkit-scrollbar-thumb {
+  background-color: #74b9ff;
+  border-radius: 10px;
 }
 
+body.dark-mode::-webkit-scrollbar {
+  width: 12px;
+  background-color: #000000;
+}
+
+body.dark-mode::-webkit-scrollbar-track {
+  border: 5px solid rgb(0, 0, 0);
+  background-color: #ffffff;
+}
+
+body.dark-mode::-webkit-scrollbar-thumb {
+  background-color: #74b9ff;
+  border-radius: 10px;
+}
 /* Preloader Starts */
 .preloader {
   position: fixed;


### PR DESCRIPTION
Pulling request for issue no: #146 
- Color of the slider track and thumb styled as per mode, giving the user a smooth experience.

**Earlier Slider:** 
<img width="62" alt="image" src="https://github.com/Kritika30032002/To-Do-List-Application/assets/56074740/209049ef-b1eb-4766-b107-100ddfe18636"> <img width="38" alt="image" src="https://github.com/Kritika30032002/To-Do-List-Application/assets/56074740/6a2f2521-d2cc-43d9-96e9-7c64fe705c5b"> 

**New Slider:** 
<img width="47" alt="image" src="https://github.com/Kritika30032002/To-Do-List-Application/assets/56074740/f57efd5b-9ea7-4725-a47c-ef610f55abbc"> <img width="35" alt="image" src="https://github.com/Kritika30032002/To-Do-List-Application/assets/56074740/53a76625-3a0c-4ef1-bc34-a0db391eedef">





