### PR TITLE
Fixed #241 Task label checked after edit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ function handleEditClick(e) {
   const editedItemText = itemInput.value;
   const editedDueDate = new Date(dueDateInput.value);
   const currentDate = new Date().toISOString().split("T")[0];
+  if (!editedItemText.trim()) {
+    displayErrorMessage("Task not entered");
+    return false;
+}
   if (editedDueDate < new Date(currentDate)) {
     displayErrorMessage("Due date has already passed");
     return false;


### PR DESCRIPTION
I have solved the bug issue [https://github.com/Kritika30032002/To-Do-List-Application/issues/241] by adding a notification instructing users to enter a label name when editing existing tasks.

![#241 issue](https://github.com/Kritika30032002/To-Do-List-Application/assets/126612568/34577eb3-782d-4e49-979f-4708ee6c2e85)
![#241 issueSolved](https://github.com/Kritika30032002/To-Do-List-Application/assets/126612568/abace363-6ea3-4415-b203-3682ed6c6a2e)


